### PR TITLE
Fix recipes version to ~3.0.

### DIFF
--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -5,7 +5,7 @@ RUN bash -c "source /usr/local/etc/entrypoint.xdebug.functions.sh && \
     disableXDebug && \
     composer global remove codeception/codeception && \
     composer global update && \
-    composer global require --dev deployer/deployer:~3.0 deployphp/recipes:dev-master && \
+    composer global require --dev deployer/deployer:~3.0 deployphp/recipes:~3.0 && \
     enableXDebug"
 COPY bin/ /usr/local/bin/
 CMD ["dep:develop"]


### PR DESCRIPTION
This avoids accidentally installing recipes for Deployer 4 which are incompatible.